### PR TITLE
Fixes bugs in helper functions

### DIFF
--- a/R/get_types.R
+++ b/R/get_types.R
@@ -37,7 +37,9 @@
 
 get_types <- function(model, query, join_by = "|"){
 
-	query <- expand_wildcard(query, join_by = join_by)
+	if(grepl(".", query, fixed = TRUE))
+		query <- expand_wildcard(query, join_by = join_by)
+	if(length(query)>1L) stop("Please specify a query of length 1L.")
 
 	# Global Variables
 	eval_var <-  reveal_outcomes(model)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -62,6 +62,9 @@ st_within <- function(x, left = "[[:punct:]]|\\b", right = "\\[", rm_left = 0, r
 }
 
 #' Recursive substitution
+#'
+#' Applies \code{gsub()} from multiple patterns to multiple replacements with 1:1 mapping.
+#'
 #' @param x A character vector.
 #' @param pattern_vector A character vector.
 #' @param replacement_vector A character vector.
@@ -93,8 +96,8 @@ expand_wildcard <- function(to_expand, join_by = "|"){
 			return(orig[i])
 		else {
 			exp_types <- strsplit(orig[i], ".", fixed = TRUE)[[1]]
-			a <- gregexpr("\\w{1}(?=(=\\.){1})", orig[i], perl = TRUE)
-			matcha <- unlist(regmatches(orig[i], a))
+			a <- gregexpr("\\w{1}\\s*(?=(=\\s*\\.){1})", orig[i], perl = TRUE)
+			matcha <- trimws(unlist(regmatches(orig[i], a)))
 			rep_n <- sapply(unique(matcha), function(e) sum(matcha == e))
 			n_types <- length(unique(matcha))
 			grid <- replicate(n_types, expr(c(0,1)))
@@ -102,8 +105,8 @@ expand_wildcard <- function(to_expand, join_by = "|"){
 			colnames(type_values) <- unique(matcha)
 
 			apply(type_values, 1, function(s){
-				to_sub <- paste0(colnames(type_values), "(\\b)*=(\\b)*$")
-				subbed <- gsub_many(exp_types, to_sub, paste0(colnames(type_values), "=", s), perl = TRUE)
+				to_sub <- paste0(colnames(type_values), "(\\s)*=(\\s)*$")
+				subbed <- gbiqq:::gsub_many(exp_types, to_sub, paste0(colnames(type_values), "=", s), perl = TRUE)
 				paste0(subbed, collapse = "")
 			})
 		}

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -3,7 +3,6 @@
 #'
 #' @param v A vector of integers indicating the number of values each variable takes on. E.g., a binary variable is represented by 2.
 #' @export
-#'
 #' @return A matrix of permutations
 #' @importFrom rlang expr
 #' @examples
@@ -62,7 +61,11 @@ st_within <- function(x, left = "[[:punct:]]|\\b", right = "\\[", rm_left = 0, r
 	sapply(1:length(starts), function(i) if(!drop[i]) substr(x, starts[i]+rm_left, stops[i]+rm_right))
 }
 
-# Recursive substitution
+#' Recursive substitution
+#' @param x A character vector.
+#' @param pattern_vector A character vector.
+#' @param replacement_vector A character vector.
+#'
 gsub_many <- function(x, pattern_vector, replacement_vector, ...){
 	if(!identical(length(pattern_vector), length(replacement_vector))) stop("pattern and replacement vectors must be the same length")
 	for(i in seq_along(pattern_vector)){

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -2,20 +2,25 @@
 #' Produces the possible permutations of a set of variables
 #'
 #' @param v A vector of integers indicating the number of values each variable takes on. E.g., a binary variable is represented by 2.
-#'
 #' @export
 #'
 #' @return A matrix of permutations
-#'
+#' @importFrom rlang expr
 #' @examples
 #'
 #' \dontrun{
-#' perm(c(2,2,2))
+#' perm(3)
 #' }
-perm <- function(v) {
-	sapply(1:length(v), function(x) {
-		rep(rep(1:v[x], each = prod(v[x:length(v)])/v[x]), length.out = prod(v))
-	}) - 1
+# perm <- function(v) {
+# 	sapply(1:length(v), function(x) {
+# 		rep(rep(1:v[x], each = prod(v[x:length(v)])/v[x]), length.out = prod(v))
+# 	}) - 1
+# }
+perm <- function(n = 2){
+	grid <- replicate(n, expr(c(0,1)))
+	perm <- do.call(expand.grid, grid)
+	colnames(perm) <- NULL
+	perm
 }
 
 #' Get string between two regular expression patterns
@@ -26,7 +31,7 @@ perm <- function(v) {
 #' @param left A regular expression to serve as look ahead.
 #' @param right A regular expression to serve as a look behind.
 #' @return A character vector.
- #' @export
+#' @export
 #' @examples
 #' a <- "(XX[Y=0] == 1) > (XX[Y=1] == 0)"
 #' st_within(a)


### PR DESCRIPTION
- Fixes following behavior in `expand_wildcard()`
> expand_wildcard("(B[A=.] == 1)")
[1] "(B[A=0] == 1 | B[A=1] == 1)"
> expand_wildcard("(B[A = .] == 1)")
[1] "()"
- Adds documentation to internal function `gsub_many()`
- Replace `perm()` helper function
