### PR TITLE
allow multiple restriction on causal types simultaneously and document

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -182,9 +182,15 @@ lookup_type <- function(model, condition = NULL, position = NULL){
 #' @param to_expand A character vector of length 1L.
 #' @param join_by A character vector of length 1L.
 #' @export
+#' @examples
+#' expand_wildcard("(Y[X=1, M=.] > Y[X=1, M=.])")
 #'
 expand_wildcard <- function(to_expand, join_by = "|"){
 	orig <- st_within(to_expand, left= "\\(", right="\\)", rm_left = 1)
+	if(is.list(orig)){
+		if(is.null(orig[[1]]))
+			stop("The character expressions to be expanded must be contained within parentheses")
+	}
 	skeleton <- gsub_many(to_expand, orig, paste0("%expand%", 1:length(orig)),
 												fixed = TRUE)
 	expand_it <- grepl("\\.", orig)

--- a/man/expand_wildcard.Rd
+++ b/man/expand_wildcard.Rd
@@ -14,3 +14,7 @@ expand_wildcard(to_expand, join_by = "|")
 \description{
 Expand statement containing wildcard
 }
+\examples{
+expand_wildcard("(Y[X=1, M=.] > Y[X=1, M=.])")
+
+}

--- a/man/set_restrictions.Rd
+++ b/man/set_restrictions.Rd
@@ -24,6 +24,8 @@ Restrict causal types. If priors exist prior probabilities are redistributed ove
 }
 \examples{
 require(dplyr)
+
+# Restrict parameter space using nodal types
 model <- make_model("X->Y") \%>\%
 set_restrictions(node_restrict = list(X = "X0", Y = "Y00"))
 get_parameter_matrix(model)
@@ -42,4 +44,18 @@ get_parameter_matrix(model)
 model <- make_model("S -> C -> Y <- R <- X; X -> C -> R") \%>\%
 set_restrictions(node_restrict = list(C = "C1000", R = "R0001", Y = "Y0001"), action = "keep")
 get_parameter_matrix(model)
+
+# Restrict parameter space using casual types
+model <- make_model("X->Y") \%>\%
+set_restrictions(causal_type_restrict = c("X == 0", "Y==0"))
+get_parameter_matrix(model)
+# Restrict to define a model with monotonicity
+model <- make_model("X->Y") \%>\%
+set_restrictions(causal_type_restrict = c("Y[X=1] < Y[X=0]"))
+get_parameter_matrix(model)
+# Restriction with a wildcard
+model <- make_model("X->Y<-M") \%>\%
+set_restrictions(causal_type_restrict = c("(Y[X=1, M=.] < Y[X=0, M=.])"))
+get_parameter_matrix(model)
+
 }


### PR DESCRIPTION
This PR

- allows to simultaneously restrict multiple causal types
- provides examples for argument `restrict_causal_types` in `set_restrictions` ( issue [#53](https://github.com/macartan/gbiqq/issues/53))
- adds error message to expand_wildcard when no parentheses are included in expression
