### PR TITLE
License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR:
-COPYRIGHT HOLDER:
+YEAR: 2019
+COPYRIGHT HOLDER: Macartan Humphreys and Alan Jacobs

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2019
+YEAR: 2020
 COPYRIGHT HOLDER: Macartan Humphreys and Alan Jacobs


### PR DESCRIPTION
closes issue #65 

Using [MIT](https://tldrlegal.com/license/mit-license) License.

Including only Alan and Macartan as copyright holders