### PR TITLE
more informative error message in map_query_to_causal_types

### DIFF
--- a/R/map_query_to_causal_type.R
+++ b/R/map_query_to_causal_type.R
@@ -77,6 +77,9 @@ map_query_to_causal_type <- function(model, query, join_by = "|") {
         dos <- list()
 
         # Walks through splitted expressions (i.e dos) and evaulates each expression when possible
+        if(length(.query) == 0) {
+        stop("query does not return any causal types.\nNote that expressions of the form `Y[]==1` are not allowed for mapping queries to causal types.\nSpecify queries as (e.g.) `Y==1` or `Y[X=0] == 1` instead.")
+        }
         for (j in 1:length(.query)) {
             do <- unlist(strsplit(.query[j], ""))
             stop <- gregexpr("=", .query[j], perl = TRUE)[[1]][1] - 1

--- a/R/map_query_to_causal_type.R
+++ b/R/map_query_to_causal_type.R
@@ -78,7 +78,7 @@ map_query_to_causal_type <- function(model, query, join_by = "|") {
 
         # Walks through splitted expressions (i.e dos) and evaulates each expression when possible
         if(length(.query) == 0) {
-        stop("query does not return any causal types.\nNote that expressions of the form `Y[]==1` are not allowed for mapping queries to causal types.\nSpecify queries as (e.g.) `Y==1` or `Y[X=0] == 1` instead.")
+            stop("\nquery does not return any causal types.\nNote that expressions of the form `Y[]==1` are not allowed for mapping queries to causal types.\nSpecify queries as (e.g.) `Y==1` or `Y[X=0] == 1` instead.")
         }
         for (j in 1:length(.query)) {
             do <- unlist(strsplit(.query[j], ""))

--- a/R/reveal_outcomes.R
+++ b/R/reveal_outcomes.R
@@ -3,7 +3,7 @@
 #' Reveal outcomes for all causal types. Calculated by sequentially calculating endogenous nodes.
 #' If a do operator is applied to any node then it takes the given value and all its descendants are generated accordingly.
 #'
-#' @details \code{reveal_outcomes} starts off by creating types (via \code{\link{map_query_to_causal_type}}). It then takes types of endogenous and reveals their outcome based on the value that their parents took. Exogenous nodes outcomes correspond to their type.
+#' @details \code{reveal_outcomes} starts off by creating types (via \code{\link{get_nodal_types}}). It then takes types of endogenous and reveals their outcome based on the value that their parents took. Exogenous nodes outcomes correspond to their type.
 #' @inheritParams gbiqq_internal_inherit_params
 #' @param dos A named \code{list}. Do actions defining node values, e.g., \code{list(X = 0, M = 1)}.
 #' @param node A character. An optional quoted name of the node whose outcome should be revealed. If specified all values of parents need to be specified via \code{dos}.

--- a/R/set_prior_distribution.R
+++ b/R/set_prior_distribution.R
@@ -16,7 +16,7 @@ make_prior_distribution <- function(model, n_draws = 4000) {
 
     priors <- model$parameters_df$priors
 
-    parameters <- unlist(sapply(unique(param_sets), function(v) rdirichlet(n_draws, priors[model$parameters_df$param_set ==
+    parameters <- unlist(sapply(param_sets, function(v) rdirichlet(n_draws, priors[model$parameters_df$param_set ==
         v])))
 
     prior_distribution <- matrix(parameters, nrow = n_draws)

--- a/man/reveal_outcomes.Rd
+++ b/man/reveal_outcomes.Rd
@@ -21,7 +21,7 @@ Reveal outcomes for all causal types. Calculated by sequentially calculating end
 If a do operator is applied to any node then it takes the given value and all its descendants are generated accordingly.
 }
 \details{
-\code{reveal_outcomes} starts off by creating types (via \code{\link{map_query_to_causal_type}}). It then takes types of endogenous and reveals their outcome based on the value that their parents took. Exogenous nodes outcomes correspond to their type.
+\code{reveal_outcomes} starts off by creating types (via \code{\link{get_nodal_types}}). It then takes types of endogenous and reveals their outcome based on the value that their parents took. Exogenous nodes outcomes correspond to their type.
 }
 \examples{
 model <- make_model("X -> Y")

--- a/tests/testthat/test_get_types.R
+++ b/tests/testthat/test_get_types.R
@@ -10,6 +10,8 @@ testthat::test_that(
 		expect_error(map_query_to_causal_type(model, query), "Variable Z is not part of the model.")
 		query <- "(Y[Z = . == 1)"
 		expect_error(map_query_to_causal_type(model, query),"Either '[' or ']' missing.", fixed = TRUE)
+		query <- "(Y[] == 1)"
+		expect_error(map_query_to_causal_type(model, query))
 	}
 )
 


### PR DESCRIPTION
This PR
- adds error messages when expressions do not return causal types
- include tests for error message above
- removes redundant code in 
- corrects function reference in `reveal_outcome`

